### PR TITLE
bug: Bullet point name for superchargejs.com

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -13,7 +13,7 @@ Supercharge’s source code is managed and hosted on GitHub:
 - [Supercharge Installer](https://github.com/superchargejs/installer)
 - [Supercharge Framework](https://github.com/superchargejs/framework)
 - [Supercharge Documentation](https://github.com/superchargejs/docs)
-- [Supercharge Documentation](https://github.com/superchargejs/superchargejs.com)
+- [Supercharge.com Website](https://github.com/superchargejs/superchargejs.com)
 
 
 ## Coding Style


### PR DESCRIPTION
Corrected the link name, to reflect the actual url.